### PR TITLE
Fix done redirect not working in subdir

### DIFF
--- a/piper_recording_studio/templates/record.html
+++ b/piper_recording_studio/templates/record.html
@@ -188,7 +188,7 @@
              if (response.ok) {
                  let result = await response.json();
                  if (result.done) {
-                     window.location.pathname = "/done.html";
+                     window.location.href = "done.html";
                      return;
                  }
                  


### PR DESCRIPTION
If piper recording studio is running in a folder such as example.com/piper-record/ then the redirect at the end was going to example.com/done.html.  

This change makes it go to example.com/piper-record/done.html