### PR TITLE
Fix typo in en-US General prompt

### DIFF
--- a/prompts/English (United States)_en-US/0000000001_0300000050_General.txt
+++ b/prompts/English (United States)_en-US/0000000001_0300000050_General.txt
@@ -50,7 +50,7 @@
 0000000050	Eating the whole grain, as our ancestors used to do, provides a host of benefits to the body that are lost when the grain is processed.
 0000000051	While my dog sniffed the ground, I opened my heart to the wonder of Nature's creation.
 0000000052	In all of its sweet seasons here, it had never failed to touch my soul.
-0000000053	The flour in white breads, bagels, pastries and pasta has lost the grain's fibber-rich outer layer during the refining process. 
+0000000053	The flour in white breads, bagels, pastries and pasta has lost the grain's fiber-rich outer layer during the refining process. 
 0000000054	It had heated my heart on the coldest days and lighted my spirit on the darkest nights.
 0000000055	Then I thanked Nature for the love that created the moon, the stars, and me.
 0000000056	I don't often eat lunch at work, and tend to just work through the day and eat dinner when I get home.


### PR DESCRIPTION
changed `fibber` (one who fibs/lies) to `fiber` (the nutrient)