### PR TITLE
Implemented skip button

### DIFF
--- a/export_dataset/__main__.py
+++ b/export_dataset/__main__.py
@@ -80,6 +80,12 @@ class ExportAudio:
         args: argparse.Namespace,
     ):
         try:
+            # Skip prompts explicitly marked as skipped in the recording UI
+            skip_path = audio_path.with_suffix(".skip")
+            if skip_path.exists():
+                _LOGGER.debug("Skipping prompt marked as skipped: %s", skip_path)
+                return
+
             text_path = audio_path.with_suffix(".txt")
             if not text_path.exists():
                 _LOGGER.warning("Missing text file: %s", text_path)

--- a/piper_recording_studio/templates/record.html
+++ b/piper_recording_studio/templates/record.html
@@ -82,7 +82,7 @@
                             <span>(press "p" to play)</span>
                           </div>
                         </div>
-                        <div class="col-auto pull-right" hidden>
+                        <div class="col-auto pull-right">
                             <button id="skip" type="submit" class="btn btn-lg btn-warning" data-action="skip">
                                 <i class="fas fa-arrow-right mr-1"></i>
                                 Skip [k]
@@ -234,16 +234,16 @@
                   if (!recording) {
                       q("#clip").play();
                   }
-              } else if(e.which == 75) {
-                  // "k"
-                  // q("#skip").click();
+             } else if(e.which == 75) {
+                 // "k"
+                  q("#skip").click();
               }
           });
 
           document.addEventListener('DOMContentLoaded', function() {
               q('#record').disabled = true;
               q('#submit').disabled = true;
-              q('#skip').disabled = true;
+              q('#skip').disabled = false;
 
               const preferredFormat = 'audio/ogg; codecs=opus';
               const audio = document.createElement('audio');
@@ -269,7 +269,6 @@
                   }
 
                   q('#record').disabled = false;
-                  q('#skip').disabled = false;
                   setAlert('Microphone ready!', 'alert-success');
               });
 


### PR DESCRIPTION
Added back skip button to ignore malformed prompts. Useful when prompts are not human double checked.
Recording app saves an empty file to signal skipped prompt. Post processing app ignores those files.